### PR TITLE
Removed readline package import (fix for Windows)

### DIFF
--- a/doomsday/cli.py
+++ b/doomsday/cli.py
@@ -1,4 +1,4 @@
-import click, datetime, calendar, random, readline
+import click, datetime, calendar, random
 from . import methods
 
 # Given that the Doomsday algorithm works for the Gregorian calendar,


### PR DESCRIPTION
For some reason this package was being imported by the script, however it's not used anywhere within it, it's actually _depreciated_ (https://pypi.org/project/readline/) and doesn't exist on Windows meaning doomsday couldn't work on it. With this pr doomsday now works on Windows! 🎉 