### PR TITLE
Test subcommand improvement

### DIFF
--- a/doomsday/cli.py
+++ b/doomsday/cli.py
@@ -183,18 +183,18 @@ def dayofweek(date, explain):
         click.echo(f'{methods.day_of_week(date.year, date.month, date.day)}')
 
 @click.command()
-@click.option('--trials', type=click.IntRange(1, 100), default=10)
-def test(trials):
+@click.option('-n', '--num-of-tests', type=click.IntRange(min=1), default=10, help="Number of tests to perform.")
+def test(num_of_tests):
     """Estimate your accuracy in calculating the day of the week."""
     correct_answers = 0
-    for i in range(trials):
+    for i in range(num_of_tests):
         date = datetime.date.fromordinal(random.randint(OCTOBER_15TH_1582, DECEMBER_31ST_2600))
         correct_answer = methods.day_of_week(date.year, date.month, date.day)
         answer = input(f'{date_str(date)}? ')
         click.echo(f'{date_str(date)} {correct_tense(date, "was", "is", "will be")} a {correct_answer}.')
         if answer == correct_answer:
             correct_answers += 1
-    click.echo(f'Accuracy: {float(correct_answers)/float(trials):.0%} over {trials} trials.')
+    click.echo(f'Accuracy: {float(correct_answers)/float(num_of_tests):.0%} over {num_of_tests} tests.')
 
 cli.add_command(leapyear)
 cli.add_command(doomscentury)

--- a/doomsday/cli.py
+++ b/doomsday/cli.py
@@ -191,10 +191,12 @@ def test(num_of_tests):
         date = datetime.date.fromordinal(random.randint(OCTOBER_15TH_1582, DECEMBER_31ST_2600))
         correct_answer = methods.day_of_week(date.year, date.month, date.day)
         answer = input(f'{date_str(date)}? ')
-        click.echo(f'{date_str(date)} {correct_tense(date, "was", "is", "will be")} a {correct_answer}.')
-        if answer == correct_answer:
+        if answer.lower() == correct_answer.lower():
+            click.echo('Correct!')
             correct_answers += 1
-    click.echo(f'Accuracy: {float(correct_answers)/float(num_of_tests):.0%} over {num_of_tests} tests.')
+        else:
+            click.echo(f'Incorrect - {date_str(date)} {correct_tense(date, "was", "is", "will be")} a {correct_answer}.')
+    click.echo(f'\nAccuracy: {correct_answers/num_of_tests:.0%} over {num_of_tests} tests.')
 
 cli.add_command(leapyear)
 cli.add_command(doomscentury)

--- a/doomsday/cli.py
+++ b/doomsday/cli.py
@@ -1,4 +1,5 @@
 import click, datetime, calendar, random, readline
+from timeit import default_timer as timer
 from . import methods
 
 # Given that the Doomsday algorithm works for the Gregorian calendar,

--- a/doomsday/cli.py
+++ b/doomsday/cli.py
@@ -185,8 +185,9 @@ def dayofweek(date, explain):
 @click.command()
 @click.option('-n', '--num-of-tests', type=click.IntRange(min=1), default=10, help="Number of tests to perform.")
 def test(num_of_tests):
-    """Estimate your accuracy in calculating the day of the week."""
+    """Test your speed and accuracy in calculating the day of the week."""
     correct_answers = 0
+    start_time = timer()
     for i in range(num_of_tests):
         date = datetime.date.fromordinal(random.randint(OCTOBER_15TH_1582, DECEMBER_31ST_2600))
         correct_answer = methods.day_of_week(date.year, date.month, date.day)
@@ -196,7 +197,9 @@ def test(num_of_tests):
             correct_answers += 1
         else:
             click.echo(f'Incorrect - {date_str(date)} {correct_tense(date, "was", "is", "will be")} a {correct_answer}.')
+    time_elapsed = timer() - start_time
     click.echo(f'\nAccuracy: {correct_answers/num_of_tests:.0%} over {num_of_tests} tests.')
+    click.echo(f'Speed:    {time_elapsed:.1f}s total, average of {time_elapsed/num_of_tests:.1f}s per test.')
 
 cli.add_command(leapyear)
 cli.add_command(doomscentury)

--- a/doomsday/cli.py
+++ b/doomsday/cli.py
@@ -1,4 +1,4 @@
-import click, datetime, calendar, random, readline
+import click, datetime, calendar, random
 from . import methods
 
 # Given that the Doomsday algorithm works for the Gregorian calendar,


### PR DESCRIPTION
Hey, I've added a couple features to the test subcommand since it's really quite useful:

1. changed option name from "--trials" to simply "-n" and added a help message for the option
2. answer is now case-insensitive
3. formatted output nicer and now actually tells user if they got it wrong or right
4. test now also times user and shows total and average times

Here is an example of how it looks now:
```
$ doomsday test -n 3
August 2nd, 2340? Friday
Correct!
December 7th, 1839? saturday
Correct!
April 27th, 2587? tuesday
Incorrect - April 27th, 2587 will be a Friday.

Accuracy: 67% over 3 tests.
Speed:    36.3s total, average of 12.1s per test.
```

Currently I use an app on my phone for daily practice but these couple of changes would change that to this script :)